### PR TITLE
Fix output path handling

### DIFF
--- a/event-horizon-cli/src/main/kotlin/com/automattic/eventhorizon/cli/Cli.kt
+++ b/event-horizon-cli/src/main/kotlin/com/automattic/eventhorizon/cli/Cli.kt
@@ -24,6 +24,7 @@ import com.github.ajalt.clikt.parameters.types.enum
 import com.github.ajalt.clikt.parameters.types.path
 import java.nio.file.Path
 import java.text.Format
+import kotlin.io.path.exists
 import kotlin.io.path.isDirectory
 
 internal class Cli : CliktCommand("event-horizon") {
@@ -97,8 +98,8 @@ internal class Cli : CliktCommand("event-horizon") {
   private fun requireCorrectOutput(outputDir: Path, format: FormatType) {
     when (format) {
       FormatType.Kotlin, FormatType.Swift, FormatType.TypeScript -> {
-        if (!outputDir.isDirectory()) {
-          throw UsageError("--output-path option must be a file in combination with $format format")
+        if (outputDir.exists() && !outputDir.isDirectory()) {
+          throw UsageError("--output-path option must be a directory in combination with $format format")
         }
       }
       FormatType.Json -> Unit

--- a/event-horizon-cli/src/test/kotlin/com/automattic/eventhorizon/cli/CliSpec.kt
+++ b/event-horizon-cli/src/test/kotlin/com/automattic/eventhorizon/cli/CliSpec.kt
@@ -77,6 +77,40 @@ class CliSpec : FunSpec({
     outputDir.resolve("event-horizon.json").shouldExist()
   }
 
+  test("generate code for non-existing output path") {
+    val outputDir = tempdir().toPath().resolve("absent")
+    inputFile.writeText("")
+
+    val result = cli.test("-i", "$inputFile", "-o", "$outputDir", "-f", "kotlin")
+
+    result.statusCode shouldBe 0
+    outputDir.resolve("EventHorizon.kt").shouldExist()
+  }
+
+  test("fail to generate code to output.file") {
+    val outputFile = tempfile()
+    inputFile.writeText("")
+
+    val result = cli.test("-i", "$inputFile", "-o", "$outputFile", "-f", "kotlin")
+
+    result.statusCode shouldBe 1
+    result.stderr shouldBe """
+      |Usage: event-horizon [<options>]
+      |
+      |Error: --output-path option must be a directory in combination with Kotlin format
+      |
+    """.trimMargin()
+  }
+
+  test("generate JSON to output file") {
+    val outputFile = tempfile()
+    inputFile.writeText("")
+
+    val result = cli.test("-i", "$inputFile", "-o", "$outputFile", "-f", "json")
+
+    result.statusCode shouldBe 0
+  }
+
   test("require output platform") {
     val outputDir = tempdir().toPath()
     inputFile.writeText(

--- a/event-horizon-cli/src/test/kotlin/com/automattic/eventhorizon/cli/CliSpec.kt
+++ b/event-horizon-cli/src/test/kotlin/com/automattic/eventhorizon/cli/CliSpec.kt
@@ -47,37 +47,7 @@ class CliSpec : FunSpec({
     outputDir.resolve("EventHorizon.kt").shouldExist()
   }
 
-  test("generate swift code") {
-    val outputDir = tempdir().toPath()
-    inputFile.writeText("")
-
-    val result = cli.test("-i", "$inputFile", "-o", "$outputDir", "-f", "swift")
-
-    result.statusCode shouldBe 0
-    outputDir.resolve("EventHorizon.swift").shouldExist()
-  }
-
-  test("generate type script code") {
-    val outputDir = tempdir().toPath()
-    inputFile.writeText("")
-
-    val result = cli.test("-i", "$inputFile", "-o", "$outputDir", "-f", "ts")
-
-    result.statusCode shouldBe 0
-    outputDir.resolve("eventHorizon.ts").shouldExist()
-  }
-
-  test("generate JSON schema") {
-    val outputDir = tempdir().toPath()
-    inputFile.writeText("")
-
-    val result = cli.test("-i", "$inputFile", "-o", "$outputDir", "-f", "json")
-
-    result.statusCode shouldBe 0
-    outputDir.resolve("event-horizon.json").shouldExist()
-  }
-
-  test("generate code for non-existing output path") {
+  test("generate Kotlin code for non-existing output path") {
     val outputDir = tempdir().toPath().resolve("absent")
     inputFile.writeText("")
 
@@ -87,7 +57,7 @@ class CliSpec : FunSpec({
     outputDir.resolve("EventHorizon.kt").shouldExist()
   }
 
-  test("fail to generate code to output.file") {
+  test("fail to generate Kotlin code to output file") {
     val outputFile = tempfile()
     inputFile.writeText("")
 
@@ -100,6 +70,86 @@ class CliSpec : FunSpec({
       |Error: --output-path option must be a directory in combination with Kotlin format
       |
     """.trimMargin()
+  }
+
+  test("generate swift code") {
+    val outputDir = tempdir().toPath()
+    inputFile.writeText("")
+
+    val result = cli.test("-i", "$inputFile", "-o", "$outputDir", "-f", "swift")
+
+    result.statusCode shouldBe 0
+    outputDir.resolve("EventHorizon.swift").shouldExist()
+  }
+
+  test("generate Swift code for non-existing output path") {
+    val outputDir = tempdir().toPath().resolve("absent")
+    inputFile.writeText("")
+
+    val result = cli.test("-i", "$inputFile", "-o", "$outputDir", "-f", "swift")
+
+    result.statusCode shouldBe 0
+    outputDir.resolve("EventHorizon.swift").shouldExist()
+  }
+
+  test("fail to generate Swift code to output file") {
+    val outputFile = tempfile()
+    inputFile.writeText("")
+
+    val result = cli.test("-i", "$inputFile", "-o", "$outputFile", "-f", "swift")
+
+    result.statusCode shouldBe 1
+    result.stderr shouldBe """
+      |Usage: event-horizon [<options>]
+      |
+      |Error: --output-path option must be a directory in combination with Swift format
+      |
+    """.trimMargin()
+  }
+
+  test("generate type script code") {
+    val outputDir = tempdir().toPath()
+    inputFile.writeText("")
+
+    val result = cli.test("-i", "$inputFile", "-o", "$outputDir", "-f", "ts")
+
+    result.statusCode shouldBe 0
+    outputDir.resolve("eventHorizon.ts").shouldExist()
+  }
+
+  test("generate type script code for non-existing output path") {
+    val outputDir = tempdir().toPath().resolve("absent")
+    inputFile.writeText("")
+
+    val result = cli.test("-i", "$inputFile", "-o", "$outputDir", "-f", "ts")
+
+    result.statusCode shouldBe 0
+    outputDir.resolve("eventHorizon.ts").shouldExist()
+  }
+
+  test("fail to generate type script code to output file") {
+    val outputFile = tempfile()
+    inputFile.writeText("")
+
+    val result = cli.test("-i", "$inputFile", "-o", "$outputFile", "-f", "ts")
+
+    result.statusCode shouldBe 1
+    result.stderr shouldBe """
+      |Usage: event-horizon [<options>]
+      |
+      |Error: --output-path option must be a directory in combination with TypeScript format
+      |
+    """.trimMargin()
+  }
+
+  test("generate JSON schema") {
+    val outputDir = tempdir().toPath()
+    inputFile.writeText("")
+
+    val result = cli.test("-i", "$inputFile", "-o", "$outputDir", "-f", "json")
+
+    result.statusCode shouldBe 0
+    outputDir.resolve("event-horizon.json").shouldExist()
   }
 
   test("generate JSON to output file") {


### PR DESCRIPTION
Checking for `!outputDir.isDirectory()` when generating code was insufficient. This condition evaluated to `true` when the directory did not exist, which prevented the code generation tool from running.  

Additionally, the tool printed an incorrect message, telling users that the output needed to be a file instead of a directory.