### PR TITLE
Make constructor for structs without properties public

### DIFF
--- a/event-horizon-generator/swift/src/main/kotlin/com/automattic/eventhorizon/swift/EventStruct.kt
+++ b/event-horizon-generator/swift/src/main/kotlin/com/automattic/eventhorizon/swift/EventStruct.kt
@@ -109,11 +109,7 @@ internal class EventStruct(
       .addProperty(eventNameProperty)
       .addProperties(structProperties.keys)
       .also { builder -> event.description?.let(builder::addDoc) }
-      .also { builder ->
-        if (structProperties.isNotEmpty()) {
-          builder.addFunction(constructor)
-        }
-      }
+      .also { builder -> builder.addFunction(constructor) }
       .build()
       .let { typeSpec -> trackableProtocol.conformType(typeSpec, trackableNameGetter, trackablePropertiesGetter) }
 }

--- a/event-horizon-generator/swift/src/test/kotlin/com/automattic/eventhorizon/swift/EventStructSpec.kt
+++ b/event-horizon-generator/swift/src/test/kotlin/com/automattic/eventhorizon/swift/EventStructSpec.kt
@@ -26,6 +26,9 @@ class EventStructSpec : FunSpec({
       |    return props
       |  }
       |
+      |  public init() {
+      |  }
+      |
       |}
       |
     """.trimMargin()
@@ -99,6 +102,9 @@ class EventStructSpec : FunSpec({
       |  public var trackableProperties: [Swift.AnyHashable : Swift.Any] {
       |    let props: [Swift.AnyHashable : Swift.Any] = [:]
       |    return props
+      |  }
+      |
+      |  public init() {
       |  }
       |
       |}


### PR DESCRIPTION
Closes [AINFRA-1397](https://linear.app/a8c/issue/AINFRA-1397/add-explicit-public-initializers-to-all-generated-event-structs)