### PR TITLE
Make Swift Event struct properties public

### DIFF
--- a/event-horizon-generator/swift/src/main/kotlin/com/automattic/eventhorizon/swift/EventStruct.kt
+++ b/event-horizon-generator/swift/src/main/kotlin/com/automattic/eventhorizon/swift/EventStruct.kt
@@ -26,5 +26,5 @@ internal class EventStruct(
       .build()
 }
 
-private val NameProperty = PropertySpec.builder("name", STRING).build()
-private val PropertiesProperty = PropertySpec.builder("properties", DictStringStringConvertible).build()
+private val NameProperty = PropertySpec.builder("name", STRING).addModifiers(Modifier.PUBLIC).build()
+private val PropertiesProperty = PropertySpec.builder("properties", DictStringStringConvertible).addModifiers(Modifier.PUBLIC).build()

--- a/event-horizon-generator/swift/src/test/kotlin/com/automattic/eventhorizon/swift/EventStructSpec.kt
+++ b/event-horizon-generator/swift/src/test/kotlin/com/automattic/eventhorizon/swift/EventStructSpec.kt
@@ -10,8 +10,8 @@ class EventStructSpec : FunSpec({
     typeSpec.toString() shouldBe """
       |public struct Event {
       |
-      |  let name: Swift.String
-      |  let properties: [Swift.String : Swift.CustomStringConvertible]
+      |  public let name: Swift.String
+      |  public let properties: [Swift.String : Swift.CustomStringConvertible]
       |
       |}
       |

--- a/event-horizon-generator/swift/src/test/kotlin/com/automattic/eventhorizon/swift/SwiftGeneratorSpec.kt
+++ b/event-horizon-generator/swift/src/test/kotlin/com/automattic/eventhorizon/swift/SwiftGeneratorSpec.kt
@@ -58,8 +58,8 @@ class SwiftGeneratorSpec : FunSpec({
       |
       |public struct Event {
       |
-      |  let name: String
-      |  let properties: [String : CustomStringConvertible]
+      |  public let name: String
+      |  public let properties: [String : CustomStringConvertible]
       |
       |}
       |

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.automattic.eventhorizon
-VERSION_NAME=0.4.1
+VERSION_NAME=0.4.2
 
 org.gradle.jvmargs=-Xms1g -Xmx4g -Dfile.encoding=UTF-8
 org.gradle.parallel=true


### PR DESCRIPTION
## Summary

The `name` and `properties` stored properties on the generated Swift `Event` struct were missing the `public` access modifier. With library evolution enabled (`-enable-library-evolution`), these defaulted to `internal`, making them invisible in the `.swiftinterface` and inaccessible to consumers of the xcframework.

This prevented clients from decomposing `Event` instances in their `eventSink` closure — the intended integration pattern for bridging EventHorizon events into an existing analytics pipeline (e.g. enriching with site-specific properties before forwarding to Tracks).

## The fix

Add `Modifier.PUBLIC` to the `name` and `properties` `PropertySpec` builders in `EventStruct.kt`.

**Before** (generated Swift):
```swift
public struct Event {
  let name: String
  let properties: [String : CustomStringConvertible]
}
```

**After**:
```swift
public struct Event {
  public let name: String
  public let properties: [String : CustomStringConvertible]
}
```